### PR TITLE
fix broken creation of StatsClient resulting from pystatd 3.2 version change

### DIFF
--- a/flask_statsd.py
+++ b/flask_statsd.py
@@ -22,8 +22,9 @@ class StatsD(object):
 
         self.app = app
 
-        self.statsd = StatsClient(self.config['STATSD_HOST'],
-            self.config['STATSD_PORT'], self.config['STATSD_PREFIX'])
+        self.statsd = StatsClient(host=self.config['STATSD_HOST'],
+            port=self.config['STATSD_PORT'],
+            prefix=self.config['STATSD_PREFIX'])
 
     def timer(self, *args, **kwargs):
         return self.statsd.timer(*args, **kwargs)


### PR DESCRIPTION
the function signature of StatsClient in pystatsd change in 3.2 to accept a ipv6 argument. Unfortunately the way flask-statd calls StatsClient results in the prefix getting passed in for the ipv6 argument. This change fixes the problem by passing in keyword arguments.

pystatd 3.2

class StatsClient(StatsClientBase):
    def **init**(self, host='localhost', port=8125, ipv6=False, prefix=None, maxudpsize=512):

pystatd 3.1

class StatsClient(StatsClientBase):
    def **init**(self, host='localhost', port=8125, prefix=None, maxudpsize=512):
